### PR TITLE
chore: prefix GitHub Action Dependabot PRs with ci

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,5 +6,5 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: fix
+      prefix: ci
       include: scope


### PR DESCRIPTION
Update the Dependabot configuration to prefix pull requests created to bump GitHub Action versions with `ci` instead of `fix`, preventing a new minor version from being created for CI/CD pipeline updates.