### PR TITLE
ci: remove workflow_run condition from CD pipeline

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,6 @@ jobs:
   deploy:
     name: Deploy to development
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: development
 
     steps:


### PR DESCRIPTION
Remove the `workflow_run` condition from the CD pipeline's deploy job. That condition was added as part of testing, when we were leveraging the `workflow_run` event to trigger deployments.