### PR TITLE
fix: update parameter names to reflect usage

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,5 +28,5 @@ jobs:
           cdk deploy
           --require-approval never
           --parameters sourceEmailAddress=${{ secrets.SOURCE_EMAIL_ADDRESS }}
-          --parameters opsgenieEmailLocalPart=${{ secrets.OPSGENIE_LOCAL_PART }}
-          --parameters opsgenieIntegrationName=${{ secrets.OPSGENIE_INTEGRATION_NAME }}
+          --parameters opsgenieIntegrationEmailLocalPart=${{ secrets.OPSGENIE_LOCAL_PART }}
+          --parameters opsgenieCustomerName=${{ secrets.OPSGENIE_CUSTOMER_NAME }}

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -9,6 +9,6 @@ tests:
   default:
     template: ./cdk.out/AwsSesIamRoleStack.template.json
     parameters:
-      sourceEmailAddress: test
-      opsgenieEmailLocalPart: test
-      opsgenieIntegrationName: test@example.com
+      sourceEmailAddress: test@example.com
+      opsgenieIntegrationEmailLocalPart: test-system
+      opsgenieCustomerName: example-customer

--- a/src/iam-role.ts
+++ b/src/iam-role.ts
@@ -17,7 +17,7 @@ export class AwsSesIamRoleStack extends cdk.Stack {
 
     const opsgenieCustomerName = new cdk.CfnParameter(
       this,
-      "sourceEmailAddress",
+      "opsgenieCustomerName",
       {
         type: "String",
         description: `The Opsgenie customer name. The customer name is used to\
@@ -28,7 +28,7 @@ export class AwsSesIamRoleStack extends cdk.Stack {
 
     const opsgenieIntegrationEmailLocalPart = new cdk.CfnParameter(
       this,
-      "opsgenieEmailLocalPart",
+      "opsgenieIntegrationEmailLocalPart",
       {
         type: "String",
         description: `The e-mail local part name, defined in the Opsgenie e-mail\
@@ -38,7 +38,7 @@ export class AwsSesIamRoleStack extends cdk.Stack {
 
     const sourceEmailAddress = new cdk.CfnParameter(
       this,
-      "opsgenieIntegrationName",
+      "sourceEmailAddress",
       {
         type: "String",
         description: `The e-mail address of the source system that will be\


### PR DESCRIPTION
Update the input parameter names in the CloudFormation template to reflect their actual usage. The TypeScript variable names were already updated, but the actual string that was synthesized in the template was not.